### PR TITLE
line map corret and close issue #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,26 +89,32 @@ function styleTagsFromHtmlExtracter(code) {
 }
 
 module.exports = function() {
-    let extractMap = [];
+    let extractMaps = [];
 
     return {
-        code(code) {
+        code(code, filepath) {
             const extracted = styleTagsFromHtmlExtracter(code);
-
-            extractMap = extracted.map;
+            extractMaps.push({
+                filepath: filepath,
+                map: extracted.map
+            });
             return extracted.code;
         },
 
-        result(result) {
+        result(result, filepath) {
             result.warnings = result.warnings.map(warning => {
-                const map = extractMap[warning.line] || {};
-
+                let extractMap = extractMaps.filter((map) => {
+                    return map.filepath === filepath;
+                });
+                const map = extractMap[0]['map'][warning.line] || {};
+                
                 if (map.line) {
                     warning.line = map.line;
                 }
                 warning.column = (map.index || 0) + warning.column;
                 return warning;
             });
+
             return result;
         },
     };


### PR DESCRIPTION
When i'm using stylelint for many .vue files, stylelint-processor-html displays the errors/sugestions but with line numbers way off, because the object(extractMap) is error,  now i check the filepath for the object(extractMap), line numbers is corret and close issue #1.

当有多个 vue 文件需要 lint 时，stylelint-processor-html 的报错行数一直不正确，最终发现 extractMap 没有引用正确的，所以引入的文件路径做校验，现在报错行数正确，可以关闭issue #1 。